### PR TITLE
Fixed hyperlinks to run locally by removing the site url variable

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,16 +1,16 @@
 	<nav id="dl-menu" class="dl-menuwrapper" role="navigation">
 		<button class="dl-trigger">Open Menu</button>
 		<ul class="dl-menu">
-			<li><a href="{{ site.url }}/">Home</a></li>
+			<li><a href="/">Home</a></li>
 			<li>
 				<a href="#">About</a>
 				<ul class="dl-submenu">
 					<li>
-						<img src="{{ site.url }}/{{ site.logo }}" alt="{{ site.title }} photo" class="author-photo">
+						<img src="/{{ site.logo }}" alt="{{ site.title }} photo" class="author-photo">
 						<h4>{{ site.title }}</h4>
 						<p>{{ site.description }}</p>
 					</li>
-					<li><a href="{{ site.url }}/about/"><span class="btn btn-inverse">Learn More</span></a></li>
+					<li><a href="/about/"><span class="btn btn-inverse">Learn More</span></a></li>
 					{% if site.email %}<li>
                         <a href="mailto:{{ site.email }}" target="_blank" rel="noopener noreferrer"><i class="fa fa-fw fa-envelope-square"></i> Email</a>
                     </li>{% endif %}
@@ -88,8 +88,8 @@
 			<li>
 				<a href="#">Posts</a>
 				<ul class="dl-submenu">
-					<li><a href="{{ site.url }}/posts/">All Posts</a></li>
-					<li><a href="{{ site.url }}/tags/">All Tags</a></li>
+					<li><a href="/posts/">All Posts</a></li>
+					<li><a href="/tags/">All Tags</a></li>
 				</ul>
 			</li>
 			{% for link in site.data.navigation %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -15,17 +15,17 @@ layout: compress
     <header class="header flex" role="banner">
         <div class="container animated fadeIn">
             <div class="row">
-                    <a href="{{ site.url }}">
+                    <a href="">
                         <img src="{{ site.logo }}" class="img-circle zoombtn animated rotateIn">
                     </a>
                     <h3 class="title">
-                        <a class="zoombtn" href="{{ site.url }}">
+                        <a class="zoombtn" href="">
                         	<p style="font-size:1.2rem;font-weight:300">{{ site.title }}</p>
 			            </a>
                     </h3>
                     <hr class="hr-line">
                     <h3 class="title">
-                        <a href="{{ site.url }}">
+                        <a href="">
                         	<p style="font-size:1rem;font-weight:300">{{ site.bio }}</p>
 			            </a>
                     </h3>
@@ -34,33 +34,33 @@ layout: compress
                   <h3 class="title">
 
 
-                         <a class="btn zoombtn" href="{{ site.url }}/about">
+                         <a class="btn zoombtn" href="/about">
                          About Me
                          </a>
 
-                         <a class="btn zoombtn" href="{{ site.url }}/posts">
+                         <a class="btn zoombtn" href="/posts">
                          Personal Projects
                          </a>
 
 
-                         <a class="btn zoombtn" href="{{ site.url }}/UX&UIPortfolio">
+                         <a class="btn zoombtn" href="/UX&UIPortfolio">
                          UX / UI Portfolio
                          </a>
-                         
 
 
-                         <a class="btn zoombtn" href="{{ site.url }}/resumeAndContactInformation">
+
+                         <a class="btn zoombtn" href="/resumeAndContactInformation">
                          Resume & Contact Information
                          </a>
 
                          <!--
-                         <a class="btn zoombtn" href="{{ site.url }}/test">
+                         <a class="btn zoombtn" href="/test">
                          Online Courses & Bootcamps
                          </a>
                          -->
 
 
-                         <a class="btn zoombtn" href="{{ site.url }}/CarletonUCoursesContent">
+                         <a class="btn zoombtn" href="/CarletonUCoursesContent">
                          Carleton U Courses & Content
                          </a>
 


### PR DESCRIPTION
When you use the {{ site.url }} variable your hyperlinks get compiled into "yoururl/yourpermalink" whilst if you are running locally you want it to be something like localhost:4000/yourpermalink. 

So you can just leave out the {{ site.url }}, the browser is smart and will figure out which url to use :)